### PR TITLE
chore(home): cleanup content links & remove duck image

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -15,10 +15,5 @@ defineOgImageComponent('Main')
       v-if="home"
       :value="home"
     />
-    <img
-      src="https://random-d.uk/api/v2/randomimg"
-      alt="Duck"
-      class="w-full rounded"
-    >
   </UPageSection>
 </template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -11,7 +11,14 @@ defineOgImageComponent('Main')
 
 <template>
   <UPageSection orientation="horizontal">
-    <ContentRenderer v-if="home" :value="home" />
-    <img src="https://random-d.uk/api/v2/randomimg" alt="Duck" class="rounded">
+    <ContentRenderer
+      v-if="home"
+      :value="home"
+    />
+    <img
+      src="https://random-d.uk/api/v2/randomimg"
+      alt="Duck"
+      class="w-full rounded"
+    >
   </UPageSection>
 </template>

--- a/content/index.md
+++ b/content/index.md
@@ -11,18 +11,20 @@ Neckbeard
 
 > Developer @ CGI Montreal · Student @ 42 Paris
 
-With over **5 years** writing **C**.
-Outside work, I build projects with **Nuxt** and **Rust** as personal pursuits.
-I plan to start **Go**.
+With over **5 years** writing [C](https://www.c-language.org/).
+Outside work, I build projects with [Nuxt](https://nuxt.com) and [Rust](https://www.rust-lang.org) as personal pursuits.
+I plan to start [Go](https://go.dev).
+
+Fan of [Gnome](https://www.gnome.org/) and [UnJs](https://unjs.io/).
 
 ::card-group
-::card{title="GitHub" icon="i-simple-icons-github" to="https://github.com/alexandre-hallaine" target="_blank"}
+::card{title="GitHub" icon="i-simple-icons-github" to="https://github.com/alexandre-hallaine" target="\_blank"}
 My open-source contributions and personal projects.
 ::
-::card{title="LinkedIn" icon="i-simple-icons-linkedin" to="https://linkedin.com/in/alexandre-hallaine" target="_blank"}
+::card{title="LinkedIn" icon="i-simple-icons-linkedin" to="https://linkedin.com/in/alexandre-hallaine" target="\_blank"}
 Connect with me professionally.
 ::
-::card{title="Bluesky" icon="i-simple-icons-bluesky" to="https://bsky.app/profile/hallaine.com" target="_blank"}
+::card{title="Bluesky" icon="i-simple-icons-bluesky" to="https://bsky.app/profile/hallaine.com" target="\_blank"}
 My thoughts and updates.
 ::
 ::card{title="Email" icon="i-lucide-mail" to="mailto:alexandre@hallaine.com"}


### PR DESCRIPTION
* Replaced bold tech keywords with markdown links in `index.md` for better SEO and UX.
* Removed the random duck image from `index.vue` to streamline layout.
* Minor cleanup in layout and attributes.
